### PR TITLE
fix: use setup node to force github workflow server to use node 16 (#89)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,11 @@ jobs:
     steps:
       - name: Checkout commit
         uses: actions/checkout@v2
+      
+      - name: Set specified node version
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install node modules
         run: npm ci


### PR DESCRIPTION
* fix: use setup node to force github workflow server to use node 16

* chore: remove unneeded comment