### PR TITLE
feat: showcase dynamic derived data with SDK

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,4 +6,6 @@ SCOPES="openid myinfo.name myinfo.passport_expiry_date myinfo.nric_number"
 DEV_AND_STAGING_SCOPES="openid sgidthirdpartymock.work_email sgidthirdpartymock.is_public_officer myinfo.nric_number myinfo.name myinfo.email myinfo.mobile_number"
 PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----woot woot-----END RSA PRIVATE KEY-----"
 OVERRIDE_DEV="http://localhost:3000"
+RULES_ENGINE_DEV_ENDPOINT="http://localhost:3001/api/rules/eval"
+SGID_RULE_IDS="ISOGPOFFICER-53270fce ISOGPOFFICER-aed06721"
 

--- a/config/index.ts
+++ b/config/index.ts
@@ -10,4 +10,4 @@ export const PORT = process.env.PORT || 10000
 export const SCOPES = process.env.SCOPES || 'openid'
 export const DEV_AND_STAGING_SCOPES =
   process.env.DEV_AND_STAGING_SCOPES || 'openid'
-export const SGID_RULE_NAMES = process.env.SGID_RULE_NAMES || ''
+export const SGID_RULE_IDS = process.env.SGID_RULE_IDS || ''

--- a/config/index.ts
+++ b/config/index.ts
@@ -7,3 +7,4 @@ export const PORT = process.env.PORT || 10000
 export const SCOPES = process.env.SCOPES || 'openid'
 export const DEV_AND_STAGING_SCOPES =
   process.env.DEV_AND_STAGING_SCOPES || 'openid'
+export const SGID_RULE_NAMES = process.env.SGID_RULE_NAMES || ''

--- a/routes/callback.ts
+++ b/routes/callback.ts
@@ -4,7 +4,7 @@ import { formatData, prettifyRuleName } from '../utils'
 import { nodeCache } from '../services/node-cache.service'
 import { SESSION_COOKIE_NAME } from '../constants'
 import { IAuthSession } from '../types'
-import { SGID_RULE_NAMES } from '../config'
+import { SGID_RULE_IDS } from '../config'
 
 /**
  * Main controller function to generate the callback page
@@ -28,14 +28,12 @@ export const callback = async (req: express.Request, res: express.Response) => {
     )
     const formattedUserInfoData = formatData(userInfoData)
 
-    const clientId = sgidService[String(state)].clientId
     const rulesData = await sgidService[String(state)].rules({
-      clientId,
       accessToken,
-      ruleNames: SGID_RULE_NAMES,
+      ruleIds: SGID_RULE_IDS,
       userInfoData,
     })
-    const formattedRulesData = rulesData.map(data => [prettifyRuleName(data.ruleName), data.output])
+    const formattedRulesData = rulesData.map(data => [prettifyRuleName(data.ruleId), data.output])
 
     res.render('callback', {
       data: [['sgID', sub], ...formattedUserInfoData, ...formattedRulesData],

--- a/services/sgid-client.service.ts
+++ b/services/sgid-client.service.ts
@@ -10,6 +10,7 @@ interface SgidServiceOption {
   privateKey: string
   redirectUri: string
   hostname: string
+  rulesEngineEndpoint: string | undefined
 }
 
 class SgidService {
@@ -22,6 +23,7 @@ class SgidService {
     privateKey,
     redirectUri,
     hostname,
+    rulesEngineEndpoint
   }: SgidServiceOption) {
     this.sgidClient = new SgidClient({
       clientId: clientId,
@@ -29,6 +31,7 @@ class SgidService {
       privateKey: privateKey,
       redirectUri: redirectUri,
       hostname: hostname,
+      rulesEngineEndpoint: rulesEngineEndpoint
     })
     this.clientId = clientId
   }
@@ -87,11 +90,10 @@ class SgidService {
   }
 
   async rules(rulesParams: RulesParams): Promise<RulesReturn> {
-    const { clientId, accessToken, ruleNames, userInfoData } = rulesParams
+    const { accessToken, ruleIds, userInfoData } = rulesParams
 
-    if (!clientId) throw new Error(`clientId cannot be empty`)
     if (!accessToken) throw new Error(`accessToken cannot be empty`)
-    if (!ruleNames) throw new Error(`ruleNames cannot be empty`)
+    if (!ruleIds) throw new Error(`ruleIds cannot be empty`)
     if (!userInfoData) throw new Error(`userInfoData cannot be empty`)
 
     try {
@@ -115,5 +117,6 @@ Object.keys(BASE_URLS).forEach((env) => {
     privateKey: process.env.PRIVATE_KEY as string,
     redirectUri: process.env.HOSTNAME + '/callback',
     hostname: BASE_URLS[env as keyof typeof BASE_URLS] as string,
+    rulesEngineEndpoint: env === 'dev' ? process.env.RULES_ENGINE_DEV_ENDPOINT : undefined
   })
 })

--- a/services/sgid-client.service.ts
+++ b/services/sgid-client.service.ts
@@ -1,4 +1,7 @@
-import SgidClient, { generatePkcePair } from '@opengovsg/sgid-client'
+import SgidClient, {
+  RulesParams,
+  RulesReturn,
+} from '@opengovsg/sgid-client'
 import { BASE_URLS } from '../config'
 
 interface SgidServiceOption {
@@ -11,6 +14,7 @@ interface SgidServiceOption {
 
 class SgidService {
   private sgidClient: SgidClient
+  clientId: string
 
   constructor({
     clientId,
@@ -26,6 +30,7 @@ class SgidService {
       redirectUri: redirectUri,
       hostname: hostname,
     })
+    this.clientId = clientId
   }
 
   /**
@@ -78,6 +83,23 @@ class SgidService {
     } catch (e) {
       console.error(e)
       throw new Error('Error retrieving user info via sgid-client')
+    }
+  }
+
+  async rules(rulesParams: RulesParams): Promise<RulesReturn> {
+    const { clientId, accessToken, ruleNames, userInfoData } = rulesParams
+
+    if (!clientId) throw new Error(`clientId cannot be empty`)
+    if (!accessToken) throw new Error(`accessToken cannot be empty`)
+    if (!ruleNames) throw new Error(`ruleNames cannot be empty`)
+    if (!userInfoData) throw new Error(`userInfoData cannot be empty`)
+
+    try {
+      const data = await this.sgidClient.rules(rulesParams)
+      return data
+    } catch (e) {
+      console.error(e)
+      throw new Error('Error retrieving rule-based fields')
     }
   }
 }

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -21,3 +21,7 @@ export const prettifyKey = (key: string): string => {
   prettified = prettified.replace(/_/g, ' ')
   return prettified.toUpperCase()
 }
+
+export const prettifyRuleName = (ruleName: string): string => {
+  return ruleName.replace(/_/g, ' ').toUpperCase()
+}


### PR DESCRIPTION
Working draft for [testing TypeScript SDK `rules()` API](https://github.com/opengovsg/sgid-client/pull/65).

# Deploy Notes
** Environment variables **:
- RULES_ENGINE_DEV_ENDPOINT: Rules Engine local endpoint, eg `"http://localhost:3001/api/rules/eval"`
- SGID_RULE_IDS: A space-separated string consisting of rule ID's passed into Rules API call, eg `"ISOGPOFFICER-53270fce ISOGPOFFICER-aed06721"`