### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [develop]
 
+permissions:
+  contents: read
+
 concurrency:
   group: test-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/opengovsg/sgid-test-app/security/code-scanning/6](https://github.com/opengovsg/sgid-test-app/security/code-scanning/6)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is restricted to the minimum required scope.  
For this workflow, the best non-breaking fix is to set workflow-level permissions to:

- `contents: read`

This supports `actions/checkout` and typical read-only CI tasks (install/build/test) without granting write access.

**Where to change:**  
File `.github/workflows/test.yml`, at the workflow root level (top-level keys), add `permissions` between `on` and `concurrency` (or any top-level location). No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
