### PR TITLE
fix(ci): replace deleted timestamp actions in Deploy workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,28 +41,18 @@ jobs:
       - name: Generate deployment package
         run: zip -r deploy.zip . -x node_modules/\* .git/\*
 
-      - name: Get timestamp
-        uses: opengovsg/action-current-time@master
-        id: current-time
-
-      - name: Run string replace
-        uses: opengovsg/replace-string-action@master
-        id: format-time
-        with:
-          pattern: '[:\.]+'
-          string: '${{ steps.current-time.outputs.time }}'
-          replace-with: '-'
-          flags: 'g'
-
       - name: Set branch specific env vars
         run: |
-          echo ${GITHUB_REF}
-          branch=${GITHUB_REF#refs/heads/}
-          echo $branch
-          echo "APPLICATION_NAME=$APPLICATION_NAME" >> $GITHUB_ENV
-          echo "ENVIRONMENT_NAME=$PRODUCTION_ENVIRONMENT_NAME" >> $GITHUB_ENV
-          echo "VERSION_LABEL_SUFFIX=prod-${{ steps.format-time.outputs.replaced }}" >> $GITHUB_ENV
-          cat $GITHUB_ENV
+          echo "${GITHUB_REF}"
+          branch="${GITHUB_REF#refs/heads/}"
+          echo "$branch"
+          # Sanitised timestamp (no ':' or '.') for the EB version label.
+          # Replaces deprecated opengovsg/action-current-time + opengovsg/replace-string-action.
+          timestamp=$(date -u +'%Y-%m-%dT%H-%M-%SZ')
+          echo "APPLICATION_NAME=$APPLICATION_NAME" >> "$GITHUB_ENV"
+          echo "ENVIRONMENT_NAME=$PRODUCTION_ENVIRONMENT_NAME" >> "$GITHUB_ENV"
+          echo "VERSION_LABEL_SUFFIX=prod-$timestamp" >> "$GITHUB_ENV"
+          cat "$GITHUB_ENV"
 
       - name: Print branch specific env vars
         run: |
@@ -71,7 +61,9 @@ jobs:
           echo VERSION_LABEL_SUFFIX=$VERSION_LABEL_SUFFIX
 
       - name: Deploy Demo Server
-        uses: opengovsg/beanstalk-deploy@master
+        # Pinned to a SHA so a future deletion/rename of the org fork can't
+        # break the deploy the way the two replaced actions just did.
+        uses: opengovsg/beanstalk-deploy@6f594ded1b0a22c5e5aa1088e7c58dc5816c92ea
         with:
           aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Problem

The Deploy workflow ([run 25901013767](https://github.com/opengovsg/sgid-test-app/actions/runs/25901013767/job/76124160606)) failed immediately after the v3.0.0 merge with:

> Unable to resolve action `opengovsg/action-current-time`, repository not found.
> Unable to resolve action `opengovsg/replace-string-action`, repository not found.

Both action repos have been deleted from the opengovsg org. They were only used to construct a colons-and-dots-free timestamp string for the Elastic Beanstalk version label (`VERSION_LABEL_SUFFIX`).

## Solution

**Fix**:

- Replaced the two missing actions with a single `date -u +'%Y-%m-%dT%H-%M-%SZ'` invocation in the existing "Set branch specific env vars" shell step. Output format is identical (`prod-2026-05-15T04-55-23Z`) so the EB version-label naming convention is preserved.

**Hardening** (so this doesn't happen again):

- Pinned `opengovsg/beanstalk-deploy` from `@master` to its current commit SHA `6f594ded1b0a22c5e5aa1088e7c58dc5816c92ea`. A future deletion / rename / default-branch change of the org fork cannot silently break the deploy.

No env-var, secret, or deploy-strategy changes. After merge, the Deploy workflow re-runs on the resulting master commit and ships v3.0.0 the way the original PR #138 intended.

## Tests

- The `Build & test` workflow runs on this PR (Test workflow already passes).
- Workflow-syntax change only; can't be exercised locally beyond inspection of the diff.

## Housekeeping Checklist

- [x] CI fix verified by inspection.
- [ ] ~Test cases~ — workflow change, no code under test.
- [ ] ~ENV_VARs~ — none changed.
- [ ] ~Monitoring~ — n/a.
- [ ] ~Docs~ — n/a.

## Deploy Notes

Merging this PR triggers the Deploy workflow on the resulting master commit. That run should now complete and deploy v3.0.0 to `sgid-demo-node16-production`.