### PR TITLE
chore(develop): bump to 3.0.0 + sync CI workflow fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,14 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      # Required for AWS OIDC federation: lets the runner request an
+      # OIDC token from GitHub that AWS STS can exchange for temporary
+      # credentials via AssumeRoleWithWebIdentity. `contents: read` is
+      # the minimum needed for actions/checkout on this private/public
+      # repo combination.
+      id-token: write
+      contents: read
     steps:
       - name: Checkout commit
         uses: actions/checkout@v4
@@ -60,13 +68,26 @@ jobs:
           echo ENVIRONMENT_NAME=$ENVIRONMENT_NAME
           echo VERSION_LABEL_SUFFIX=$VERSION_LABEL_SUFFIX
 
+      - name: Configure AWS credentials (OIDC)
+        # Replaces the long-lived AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+        # secrets. AssumeRoleWithWebIdentity exchanges the GitHub OIDC
+        # token for short-lived STS credentials (1h) which the next step
+        # consumes via AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and
+        # AWS_SESSION_TOKEN env vars.
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          role-session-name: gh-actions-sgid-demo-deploy
+          aws-region: ap-southeast-1
+
       - name: Deploy Demo Server
         # Pinned to a SHA so a future deletion/rename of the org fork can't
         # break the deploy the way the two replaced actions just did.
         uses: opengovsg/beanstalk-deploy@6f594ded1b0a22c5e5aa1088e7c58dc5816c92ea
         with:
-          aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_access_key: ${{ env.AWS_ACCESS_KEY_ID }}
+          aws_secret_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          aws_session_token: ${{ env.AWS_SESSION_TOKEN }}
           application_name: ${{ env.APPLICATION_NAME }}
           environment_name: ${{ env.ENVIRONMENT_NAME }}
           version_label: demo-${{ env.VERSION_LABEL_SUFFIX }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,28 +41,18 @@ jobs:
       - name: Generate deployment package
         run: zip -r deploy.zip . -x node_modules/\* .git/\*
 
-      - name: Get timestamp
-        uses: opengovsg/action-current-time@master
-        id: current-time
-
-      - name: Run string replace
-        uses: opengovsg/replace-string-action@master
-        id: format-time
-        with:
-          pattern: '[:\.]+'
-          string: '${{ steps.current-time.outputs.time }}'
-          replace-with: '-'
-          flags: 'g'
-
       - name: Set branch specific env vars
         run: |
-          echo ${GITHUB_REF}
-          branch=${GITHUB_REF#refs/heads/}
-          echo $branch
-          echo "APPLICATION_NAME=$APPLICATION_NAME" >> $GITHUB_ENV
-          echo "ENVIRONMENT_NAME=$PRODUCTION_ENVIRONMENT_NAME" >> $GITHUB_ENV
-          echo "VERSION_LABEL_SUFFIX=prod-${{ steps.format-time.outputs.replaced }}" >> $GITHUB_ENV
-          cat $GITHUB_ENV
+          echo "${GITHUB_REF}"
+          branch="${GITHUB_REF#refs/heads/}"
+          echo "$branch"
+          # Sanitised timestamp (no ':' or '.') for the EB version label.
+          # Replaces deprecated opengovsg/action-current-time + opengovsg/replace-string-action.
+          timestamp=$(date -u +'%Y-%m-%dT%H-%M-%SZ')
+          echo "APPLICATION_NAME=$APPLICATION_NAME" >> "$GITHUB_ENV"
+          echo "ENVIRONMENT_NAME=$PRODUCTION_ENVIRONMENT_NAME" >> "$GITHUB_ENV"
+          echo "VERSION_LABEL_SUFFIX=prod-$timestamp" >> "$GITHUB_ENV"
+          cat "$GITHUB_ENV"
 
       - name: Print branch specific env vars
         run: |
@@ -71,7 +61,9 @@ jobs:
           echo VERSION_LABEL_SUFFIX=$VERSION_LABEL_SUFFIX
 
       - name: Deploy Demo Server
-        uses: opengovsg/beanstalk-deploy@master
+        # Pinned to a SHA so a future deletion/rename of the org fork can't
+        # break the deploy the way the two replaced actions just did.
+        uses: opengovsg/beanstalk-deploy@6f594ded1b0a22c5e5aa1088e7c58dc5816c92ea
         with:
           aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sgid-test-app",
-  "version": "2.0.3",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sgid-test-app",
-      "version": "2.0.3",
+      "version": "3.0.0",
       "license": "ISC",
       "dependencies": {
         "@opengovsg/sgid-client": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sgid-test-app",
-  "version": "2.0.3",
+  "version": "3.0.0",
   "description": "This is an example node application that implements sgID's OAuth2 API.",
   "main": "dist/index.js",
   "engines": {


### PR DESCRIPTION
## Problem

`develop` is currently behind `master`:

- `package.json` is still `2.0.3`; master is `3.0.0` (bumped via #138).
- `.github/workflows/main.yml` still references the two deleted opengovsg actions (`action-current-time`, `replace-string-action`). PR #140 already fixed this on master.
- `.github/workflows/main.yml` still uses static AWS keys; PR #142 switches master to OIDC because the static keys are no longer valid.

Without this PR, any future `develop → master` release would carry a confusing version downgrade, a CI regression, and an auth regression.

## Solution

Three changes that exactly mirror what's on master:

- `package.json` + `package-lock.json`: `2.0.3` → `3.0.0`.
- `.github/workflows/main.yml`: replace the two deleted actions with an inline `date -u` step, and pin `opengovsg/beanstalk-deploy` from `@master` to commit SHA `6f594ded...` (mirrors PR #140).
- `.github/workflows/main.yml`: add OIDC `permissions`, the `aws-actions/configure-aws-credentials@v4` step, and pass session tokens through to `beanstalk-deploy` (mirrors PR #142).

Because the file content is byte-identical to master after both #140 and #142 land, future merges between the two branches will be no-ops on these files.

## Required setup (same as #142)

The `AWS_DEPLOY_ROLE_ARN` repo secret must exist in GitHub Settings before any push to master triggers a deploy. Develop doesn't deploy, so this PR can merge first without that secret in place — but the master-side PR (#142) needs it.

## Tests

`Build & test` runs on this PR. The workflow change is only exercised by pushes to `master`, so it can't be tested on this branch beyond inspection — but the diffs are identical to PRs #140 and #142.

## Housekeeping Checklist

- [x] Test cases already covered by #137.
- [ ] ~ENV_VARs~ — no app-level changes.
- [ ] ~Monitoring~ — n/a.
- [ ] ~Docs~ — n/a.

## Deploy Notes

No deploy triggered — `develop` isn't a deploy branch.