### PR TITLE
fix(ci): switch AWS auth to OIDC federation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,14 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      # Required for AWS OIDC federation: lets the runner request an
+      # OIDC token from GitHub that AWS STS can exchange for temporary
+      # credentials via AssumeRoleWithWebIdentity. `contents: read` is
+      # the minimum needed for actions/checkout on this private/public
+      # repo combination.
+      id-token: write
+      contents: read
     steps:
       - name: Checkout commit
         uses: actions/checkout@v4
@@ -60,13 +68,26 @@ jobs:
           echo ENVIRONMENT_NAME=$ENVIRONMENT_NAME
           echo VERSION_LABEL_SUFFIX=$VERSION_LABEL_SUFFIX
 
+      - name: Configure AWS credentials (OIDC)
+        # Replaces the long-lived AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+        # secrets. AssumeRoleWithWebIdentity exchanges the GitHub OIDC
+        # token for short-lived STS credentials (1h) which the next step
+        # consumes via AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and
+        # AWS_SESSION_TOKEN env vars.
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          role-session-name: gh-actions-sgid-demo-deploy
+          aws-region: ap-southeast-1
+
       - name: Deploy Demo Server
         # Pinned to a SHA so a future deletion/rename of the org fork can't
         # break the deploy the way the two replaced actions just did.
         uses: opengovsg/beanstalk-deploy@6f594ded1b0a22c5e5aa1088e7c58dc5816c92ea
         with:
-          aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_access_key: ${{ env.AWS_ACCESS_KEY_ID }}
+          aws_secret_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          aws_session_token: ${{ env.AWS_SESSION_TOKEN }}
           application_name: ${{ env.APPLICATION_NAME }}
           environment_name: ${{ env.ENVIRONMENT_NAME }}
           version_label: demo-${{ env.VERSION_LABEL_SUFFIX }}


### PR DESCRIPTION
## Problem

The deploy after v3.0.0 failed with:

> Error: Deployment failed: Error: Status: 403. Code: InvalidClientTokenId, Message: The security token included in the request is invalid.

The static `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` repo secrets are no longer recognised by AWS — the underlying IAM user or key has been removed or rotated. Rather than minting a new long-lived key, this PR migrates the deploy workflow to **AWS OIDC federation**, which:

- removes long-lived keys from this repo entirely (smaller blast radius if anything leaks)
- uses short-lived (1h) STS credentials per deploy
- is the AWS- and GitHub-recommended pattern for CI deploys

## Solution

Workflow-only change (1 file, +23 / -2):

1. **Job permissions** — added `id-token: write` + `contents: read` on the `deploy` job so the runner can request an OIDC token from GitHub.
2. **New step `Configure AWS credentials (OIDC)`** — uses `aws-actions/configure-aws-credentials@v4` to `AssumeRoleWithWebIdentity` against the IAM role pointed to by a new `AWS_DEPLOY_ROLE_ARN` repo secret. This populates `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` env vars for the rest of the job.
3. **`Deploy Demo Server` step** — now passes `aws_access_key`, `aws_secret_key`, **and `aws_session_token`** from those env vars (instead of from the now-defunct repo secrets). The pinned `beanstalk-deploy` SHA already supports `aws_session_token` as an input — verified in its `action.yml`.

## ⚠️ Required action before merging

The reviewer / author must, in AWS + GitHub repo settings:

1. **In AWS IAM** (already done per the PR author): an IAM role exists with:
   - a trust policy allowing `sts:AssumeRoleWithWebIdentity` from `token.actions.githubusercontent.com`, scoped to `repo:opengovsg/sgid-test-app:ref:refs/heads/master` (and any other refs you want to allow).
   - permissions to call `elasticbeanstalk:CreateApplicationVersion`, `elasticbeanstalk:UpdateEnvironment`, `s3:PutObject` on the EB application bucket, and `s3:GetBucketLocation` / `s3:CreateBucket` if it ever needs to provision a new bucket.
2. **In GitHub** (Settings → Secrets and variables → Actions → New repository secret):
   - **Name**: `AWS_DEPLOY_ROLE_ARN`
   - **Value**: the IAM role ARN (e.g. `arn:aws:iam::123456789012:role/sgid-test-app-deploy`)
3. **After this PR merges and a deploy succeeds**, delete the now-unused legacy secrets:
   - `AWS_ACCESS_KEY_ID`
   - `AWS_SECRET_ACCESS_KEY`

## Tests

- `Build & test` workflow runs on this PR automatically.
- The OIDC exchange and EB deploy can only be exercised end-to-end by a push to `master`, so verification happens on merge.

## Housekeeping Checklist

- [x] Workflow change reviewed by inspection.
- [ ] **Reviewer to confirm**: `AWS_DEPLOY_ROLE_ARN` repo secret is set before merging.
- [ ] **After deploy succeeds**: delete legacy `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` repo secrets.
- [ ] ~ENV_VARs in 1Password / EB config~ — no app-level env-var names changed.
- [ ] ~Monitoring, Docs, Notion~ — n/a.

## Deploy Notes

Merging triggers the Deploy workflow on the resulting master commit. If `AWS_DEPLOY_ROLE_ARN` is not set, the `Configure AWS credentials (OIDC)` step will fail with a clear "Could not assume role" error and the EB deploy step won't run — fail-fast, no partial state.

**Rollback**: same as before — redeploy the prior application version from the EB console. The OIDC swap is purely auth-side; if it fails, the previous deploy continues to serve traffic.