### PR TITLE
fix: normalise PRIVATE_KEY PEM and add env-var preflight

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
+import './utils/preflight'
 import { createApp } from './app'
 import { PORT } from './config'
 

--- a/services/sgid-client.service.ts
+++ b/services/sgid-client.service.ts
@@ -1,5 +1,6 @@
 import SgidClient, { generatePkcePair } from '@opengovsg/sgid-client'
 import { BASE_URLS } from '../config'
+import { normalisePem } from '../utils/pem'
 
 interface SgidServiceOption {
   clientId: string
@@ -85,12 +86,14 @@ class SgidService {
 // Initialised the sgidService object with the different environments
 export const sgidService: { [index: string]: SgidService } = {}
 
+const privateKey = normalisePem(process.env.PRIVATE_KEY)
+
 Object.keys(BASE_URLS).forEach((env) => {
   // Initialise the sgidService object with the different environments
   sgidService[env] = new SgidService({
     clientId: process.env.CLIENT_ID as string,
     clientSecret: process.env.CLIENT_SECRET as string,
-    privateKey: process.env.PRIVATE_KEY as string,
+    privateKey,
     redirectUri: process.env.HOSTNAME + '/callback',
     hostname: BASE_URLS[env as keyof typeof BASE_URLS] as string,
   })

--- a/test/index.ts
+++ b/test/index.ts
@@ -3,6 +3,7 @@
 // so importing each suite here is enough.
 
 import './utils.test'
+import './utils.pem.test'
 import './routes/profile.test'
 import './routes/home.test'
 import './routes/callback.test'

--- a/test/utils.pem.test.ts
+++ b/test/utils.pem.test.ts
@@ -1,0 +1,42 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { normalisePem } from '../utils/pem'
+
+describe('utils.normalisePem', () => {
+  const wellFormed =
+    '-----BEGIN RSA PRIVATE KEY-----\n' +
+    'MIIEowIBAAKCAQEAxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n' +
+    'yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy\n' +
+    '-----END RSA PRIVATE KEY-----\n'
+
+  test('returns input unchanged when it already contains newlines', () => {
+    assert.equal(normalisePem(wellFormed), wellFormed)
+  })
+
+  test('rehydrates a flattened single-line PEM into wrapped lines', () => {
+    const flattened =
+      '-----BEGIN RSA PRIVATE KEY----- MIIEowIBAAKCAQEAxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy -----END RSA PRIVATE KEY-----'
+    const result = normalisePem(flattened)
+    assert.match(result, /^-----BEGIN RSA PRIVATE KEY-----\n/)
+    assert.match(result, /\n-----END RSA PRIVATE KEY-----\n$/)
+    // No line in the body should exceed 64 chars.
+    const bodyLines = result.split('\n').slice(1, -2)
+    assert.ok(bodyLines.every((l) => l.length <= 64))
+  })
+
+  test('works for PKCS#8 PRIVATE KEY label too', () => {
+    const flattened =
+      '-----BEGIN PRIVATE KEY----- AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHHIIIIJJJJKKKKLLLLMMMMNNNNOOOOPPPP -----END PRIVATE KEY-----'
+    const result = normalisePem(flattened)
+    assert.match(result, /^-----BEGIN PRIVATE KEY-----\n/)
+    assert.match(result, /\n-----END PRIVATE KEY-----\n$/)
+  })
+
+  test('returns empty string for undefined input', () => {
+    assert.equal(normalisePem(undefined), '')
+  })
+
+  test('returns input unchanged if no PEM markers present', () => {
+    assert.equal(normalisePem('not a pem'), 'not a pem')
+  })
+})

--- a/utils/pem.ts
+++ b/utils/pem.ts
@@ -1,0 +1,28 @@
+/**
+ * Rehydrate a PEM block whose newlines have been flattened to spaces.
+ *
+ * Some sources strip real newlines from env-var values as they pass through
+ * (EB console paste, AWS CLI without `--cli-input-json`, some secrets
+ * managers). `node-rsa` (used by `@opengovsg/sgid-client` for its
+ * PKCS#1 -> PKCS#8 conversion) is strict about PEM formatting and throws
+ * `Invalid RSA private key` if the body isn't on separate lines. This
+ * function turns
+ *
+ *   "-----BEGIN RSA PRIVATE KEY----- MIIEow...== -----END RSA PRIVATE KEY-----"
+ *
+ * back into a standard PEM with a header line, 64-char-wide base64 lines,
+ * and a footer line. Input that already contains newlines is returned
+ * unchanged.
+ */
+export const normalisePem = (raw: string | undefined): string => {
+  if (!raw) return ''
+  if (raw.includes('\n')) return raw
+
+  const match = raw.match(/-----BEGIN ([^-]+)-----\s*(.+?)\s*-----END \1-----/)
+  if (!match) return raw
+
+  const label = match[1].trim()
+  const body = match[2].replace(/\s+/g, '')
+  const wrapped = body.match(/.{1,64}/g)?.join('\n') ?? body
+  return `-----BEGIN ${label}-----\n${wrapped}\n-----END ${label}-----\n`
+}

--- a/utils/preflight.ts
+++ b/utils/preflight.ts
@@ -1,0 +1,18 @@
+/**
+ * Fail fast with a clear, named error if required env vars are missing.
+ *
+ * Imported as a bare side-effect from `index.ts` so it runs before any
+ * downstream module that would otherwise crash inside a third-party
+ * library with a less obvious stack trace.
+ */
+const required = ['CLIENT_ID', 'CLIENT_SECRET', 'PRIVATE_KEY', 'HOSTNAME'] as const
+
+const missing = required.filter((k) => !process.env[k])
+
+if (missing.length > 0) {
+  console.error(
+    `Missing required environment variables: ${missing.join(', ')}. ` +
+      `Set them on the deployment environment before starting the app.`,
+  )
+  process.exit(1)
+}


### PR DESCRIPTION
## Problem

Every EB instance for v3.0.0 was crash-looping with:

\`\`\`
Error: Invalid RSA private key
  at RSAKey.setPrivate (node-rsa/src/libs/rsa.js:160)
  at convertPkcs1ToPkcs8 (@opengovsg/sgid-client/dist/util.js:12)
  at new SgidClient
  at new SgidService (services/sgid-client.service.ts:20)
\`\`\`

The \`PRIVATE_KEY\` env var on EB lost its newlines somewhere in transit (EB console paste, AWS CLI without proper JSON escaping, etc.). The bump from \`@opengovsg/sgid-client\` 2.0 → 2.3 in #138 added an internal PKCS#1 → PKCS#8 conversion step that uses \`node-rsa\`, which is strict about PEM formatting and refuses a single-line PEM body.

The crash happens **at module load**, inside the \`Object.keys(BASE_URLS).forEach(...)\` loop in \`services/sgid-client.service.ts\`, before \`app.listen()\` ever runs. Result: systemd-managed \`web.service\` dies seconds after start → ELB health checks fail → instances unhealthy → subsequent application deployments time out trying to act on a broken instance (the 14m \"TimedOut: 1\" deploys you've been seeing).

## Solution

Two defensive changes so this class of issue cannot crash the app again:

### 1. PEM normaliser — \`utils/pem.ts\`

\`normalisePem()\` rehydrates a flattened single-line PEM back into a standard wrapped form (header line, 64-char-wide base64 body, footer line). Input that already contains newlines is passed through unchanged. \`services/sgid-client.service.ts\` now feeds \`process.env.PRIVATE_KEY\` through this before handing it to \`SgidClient\`.

### 2. Startup env-var preflight — \`utils/preflight.ts\`

Side-effect module imported first from \`index.ts\`. Fails fast with a clear, named message and exit code 1 if any of \`CLIENT_ID\`, \`CLIENT_SECRET\`, \`PRIVATE_KEY\`, or \`HOSTNAME\` is missing:

\`\`\`
Missing required environment variables: CLIENT_ID, PRIVATE_KEY. Set them on the deployment environment before starting the app.
\`\`\`

Replaces the 6-frame-deep \`client_id is required\` stack trace with one line that EB log streams surface immediately.

## Tests

5 new test cases for \`normalisePem\` (happy path, flattened PKCS#1, flattened PKCS#8, \`undefined\`, non-PEM input). Existing 21 tests unchanged. **26 / 26 passing.**

End-to-end verification: built a clean prod-mode bundle, set \`PRIVATE_KEY\` to a flattened single-line key (reproducing the EB failure mode), booted with \`PORT=8080 NODE_ENV=production\` — app starts, \`GET /\` returns 200. Without the fix, the same boot crashes at module load.

## Housekeeping Checklist

- [x] Test cases added for the normaliser.
- [ ] ~ENV_VARs in 1Password / EB config~ — operational follow-up listed below.
- [ ] ~Monitoring, Docs, Notion~ — n/a.

## Deploy Notes

**This is the actual fix for the v3.0.0 deploy outage.** Merging triggers another Deploy run; the rolled instances should now boot the app cleanly even with the existing (flattened) \`PRIVATE_KEY\` value still in EB env config.

**Operational follow-up that should still happen** (independent of this PR): in the EB console, re-paste the \`PRIVATE_KEY\` value with proper newlines from 1Password so the stored value is correct at rest. The code fix patches the runtime; the env var should also be valid as stored.

**Rollback**: same as before — redeploy the prior application version from the EB console. The fix is purely additive (two new utility modules, two call-site changes) and can't make the existing behaviour worse.